### PR TITLE
Added workaround for BNO055 orientation firmware bug.

### DIFF
--- a/RTIMULib/IMUDrivers/RTIMUBNO055.cpp
+++ b/RTIMULib/IMUDrivers/RTIMUBNO055.cpp
@@ -131,16 +131,16 @@ int RTIMUBNO055::IMUGetPollInterval()
 
 bool RTIMUBNO055::IMURead()
 {
-    unsigned char buffer[24];
+    unsigned char buffer[32];
 
     if ((RTMath::currentUSecsSinceEpoch() - m_lastReadTime) < m_sampleInterval)
         return false;                                       // too soon
 
     m_lastReadTime = RTMath::currentUSecsSinceEpoch();
-    if (!m_settings->HALRead(m_slaveAddr, BNO055_ACCEL_DATA, 24, buffer, "Failed to read BNO055 data"))
+    if (!m_settings->HALRead(m_slaveAddr, BNO055_ACCEL_DATA, 32, buffer, "Failed to read BNO055 data"))
         return false;
 
-    int16_t x, y, z;
+    int16_t w, x, y, z;
 
     // process accel data
 
@@ -172,19 +172,23 @@ bool RTIMUBNO055::IMURead()
     m_imuData.gyro.setY(-(RTFLOAT)x / 900.0);
     m_imuData.gyro.setZ(-(RTFLOAT)z / 900.0);
 
-    // process euler angles
+    // process quaternion data
 
-    x = (((uint16_t)buffer[19]) << 8) | ((uint16_t)buffer[18]);
-    y = (((uint16_t)buffer[21]) << 8) | ((uint16_t)buffer[20]);
-    z = (((uint16_t)buffer[23]) << 8) | ((uint16_t)buffer[22]);
+    w = (((uint16_t)buffer[25]) << 8) | ((uint16_t)buffer[24]);
+    x = (((uint16_t)buffer[27]) << 8) | ((uint16_t)buffer[26]);
+    y = (((uint16_t)buffer[29]) << 8) | ((uint16_t)buffer[28]);
+    z = (((uint16_t)buffer[31]) << 8) | ((uint16_t)buffer[30]);
 
     //  put in structure and do axis remap
 
-    m_imuData.fusionPose.setX((RTFLOAT)y / 900.0);
-    m_imuData.fusionPose.setY((RTFLOAT)z / 900.0);
-    m_imuData.fusionPose.setZ((RTFLOAT)x / 900.0);
+    m_imuData.fusionQPose.setScalar((RTFLOAT)w / 16384.0);
+    m_imuData.fusionQPose.setX(-(RTFLOAT)y / 16384.0);
+    m_imuData.fusionQPose.setY(-(RTFLOAT)x / 16384.0);
+    m_imuData.fusionQPose.setZ(-(RTFLOAT)z / 16384.0);
 
-    m_imuData.fusionQPose.fromEuler(m_imuData.fusionPose);
+    // update euler data
+
+    m_imuData.fusionQPose.toEuler(m_imuData.fusionPose);
 
     m_imuData.timestamp = RTMath::currentUSecsSinceEpoch();
     return true;


### PR DESCRIPTION
The BNO055 Euler outputs have a math bug in firmware 0x0311 - the angles become increasingly distorted as you tilt the sensor beyond about 20 degrees, and at some steep orientations they jump by large angles. 
See this thread: [https://forums.adafruit.com/viewtopic.php?f=19&p=620844#p620851](url)

I've updated this library to read the quaternion data from the BNO055 instead which does not contain any bugs.